### PR TITLE
Fix for older Emacs

### DIFF
--- a/fxrd-mode.el
+++ b/fxrd-mode.el
@@ -109,6 +109,12 @@
 ;;; Utility functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; save-mark-and-excursion in Emacs 25 works like save-excursion did before
+(eval-when-compile
+  (when (not (fboundp 'save-mark-and-excursion))
+    (defmacro save-mark-and-excursion (&rest body)
+      `(save-excursion ,@body))))
+
 (defun current-line-pos ()
   "Yields the current position within the line"
   ;; TODO: find a better way to find position within a line


### PR DESCRIPTION
Because save-mark-and-excursion is implemented only in development
Emacs.

There is following byte-compile warning with Emacs 24.5(current stable version) or lower.

```
In end of data:
fxrd-mode.el:427:1:Warning: the following functions are not known to be defined: 
    save-mark-and-excursion 
```
