### PR TITLE
Update fxrd-validators.el for newer emacs

### DIFF
--- a/fxrd-validators.el
+++ b/fxrd-validators.el
@@ -2,6 +2,7 @@
 ;;; We need lexical-binding so we can create closures.
 
 (require 'eieio-base)
+(require 'eieio-compat)
 (require 's)
 
 (defclass fxrd-validator (eieio-named)


### PR DESCRIPTION
Add `eieio-compat` to make it work on contemporary emacs

Fixes issue #6