### PR TITLE
refactor: Use cl-defmethod instead of deprecated defmethod

### DIFF
--- a/fxrd-validators.el
+++ b/fxrd-validators.el
@@ -4,6 +4,7 @@
 (require 'eieio-base)
 (require 'eieio-compat)
 (require 's)
+(require 'cl-lib)
 
 (defclass fxrd-validator (eieio-named)
   (;; Public slots
@@ -50,7 +51,7 @@
    (regex :initform "^.*$"
           :documentation "Regex to validate field against"))
   "The base validator class for all field validation types")
-(defmethod fxrd-validate (val field)
+(cl-defmethod fxrd-validate (val field)
   "Validate the field with the given validator"
   (fxrd-general-validator val field))
 
@@ -97,7 +98,7 @@ specialized if necessary."
    (comp-transform :initform #'string-to-number)
    (regex :initform "[[:digit:]]*"))
   "Integer fields")
-(defmethod fxrd-validate :after ((val fxrd-numeric-v) field-value)
+(cl-defmethod fxrd-validate :after ((val fxrd-numeric-v) field-value)
   (let ((value (funcall (slot-value val 'comp-transform) field-value))
         (min (slot-value val 'min))
         (max (slot-value val 'max)))

--- a/fxrd-validators.el
+++ b/fxrd-validators.el
@@ -2,7 +2,6 @@
 ;;; We need lexical-binding so we can create closures.
 
 (require 'eieio-base)
-(require 'eieio-compat)
 (require 's)
 (require 'cl-lib)
 


### PR DESCRIPTION
Using aider and Gemini, used AI to update the references to `defmethod` with `cl-defmethod`

It doesn't seem like it should be as simple as changing the method names, but that's all that AI did